### PR TITLE
Change notice file generation workflow to use chariott bot email

### DIFF
--- a/.github/workflows/notice-generation.yaml
+++ b/.github/workflows/notice-generation.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
       - run: |
-          git config --global user.email "noreply@github.com"
+          git config --global user.email "chariott-bot@eclipse.org"
           git config --global user.name "Automated Notice Generation Pipeline"
           ./tools/notice_generation.sh
         shell: bash

--- a/.github/workflows/notice-generation.yaml
+++ b/.github/workflows/notice-generation.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
       - run: |
-          git config --global user.email "sdv-ivm@example.com"
+          git config --global user.email "noreply@github.com"
           git config --global user.name "Automated Notice Generation Pipeline"
           ./tools/notice_generation.sh
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
+checksum = "1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731"
+checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Resolves #160 

## Motivation and Context
Our notice file generation workflow creates PRs with the latest changes in the notice file. This previously used a placeholder email address as the author, which was not approved by Eclipse's policies. This is following their second suggestion of using the "respective bot mail for automated processes like workflows."

## Description
Use chariott-bot@eclipse.org as the author for notice file generation workflow.
