### PR TITLE
Have security audit treat warnings related to a crate as errors too

### DIFF
--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -20,4 +20,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: cargo audit
+      - run: cargo audit -D warnings


### PR DESCRIPTION
## Description
In security audit use cargo audit -D warnings to treat crate warnings as errors.