### PR TITLE
Update to v2 of the mobilenet model, which seems more compatible in multiple environments

### DIFF
--- a/examples/applications/local-object-detection/models/readme.txt
+++ b/examples/applications/local-object-detection/models/readme.txt
@@ -1,5 +1,5 @@
 Model used in this folder is 'ssd_mobilenet_v2_coco' taken from
 https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md.
-There is also the 'ssd_mobilenet_v1_coco', from the same place, which can be used in WSL Ubuntu 20.04,
-but has had some compatibility issues in other environments.
+This folder also contains 'ssd_mobilenet_v1_coco' from the same directory, which can be used in WSL 
+Ubuntu 20.04 but has had some compatibility issues in other environments.
 

--- a/examples/applications/local-object-detection/models/readme.txt
+++ b/examples/applications/local-object-detection/models/readme.txt
@@ -1,5 +1,4 @@
 Model used in this folder is 'ssd_mobilenet_v2_coco' taken from
 https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md.
-This folder also contains 'ssd_mobilenet_v1_coco' from the same directory, which can be used in WSL 
+This folder also contains 'ssd_mobilenet_v1_coco' from the same directory, which can be used in WSL
 Ubuntu 20.04 but has had some compatibility issues in other environments.
-

--- a/examples/applications/local-object-detection/models/readme.txt
+++ b/examples/applications/local-object-detection/models/readme.txt
@@ -1,1 +1,5 @@
-Model used in this folder is 'ssd_mobilenet_v1_coco' taken from https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md
+Model used in this folder is 'ssd_mobilenet_v2_coco' taken from
+https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md.
+There is also the 'ssd_mobilenet_v1_coco', from the same place, which can be used in WSL Ubuntu 20.04,
+but has had some compatibility issues in other environments.
+

--- a/examples/applications/local-object-detection/models/ssd_mobilenet_v2_coco.pb
+++ b/examples/applications/local-object-detection/models/ssd_mobilenet_v2_coco.pb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a8d8a89d695842e60d8c6d144181100555563e21acf2fa1e8f561fec5c3c6ad
+size 69688296

--- a/examples/applications/local-object-detection/src/detection.rs
+++ b/examples/applications/local-object-detection/src/detection.rs
@@ -25,7 +25,7 @@ pub struct DetectionLogic {
 impl DetectionLogic {
     pub fn new() -> Self {
         let mut graph = Graph::new();
-        let proto = include_bytes!("../models/ssd_mobilenet_v1_coco.pb");
+        let proto = include_bytes!("../models/ssd_mobilenet_v2_coco.pb");
 
         graph.import_graph_def(proto, &ImportGraphDefOptions::new()).unwrap();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Fixes #146 

## Motivation and Context
The old object detection model had some compatibility issues in environments outside of WSL Ubuntu 20.04 (i.e. Hyper-V VMs).

## Description
<!--- Describe your changes in detail -->
Added the new model, v2 of the mobilenet and use it in the local object detection application. A reminder for users that they can replace this model with an object detection model of their choice, and that the local object detection app may be slower and less accurate than the cloud object detection which uses Azure Cognitive Services.
<!--

