### PR TITLE
Address devskim warnings

### DIFF
--- a/ess/src/ess.rs
+++ b/ess/src/ess.rs
@@ -369,7 +369,7 @@ where
     ClientId: Eq + Hash,
     EventId: Eq + Hash,
 {
-    #[allow(clippy::too_many_arguments)] // TODO address too many arguments
+    #[allow(clippy::too_many_arguments)] // DevSkim: ignore DS176209 TODO address too many arguments
     async fn serve_with_handlers(
         mut self,
         f: impl Fn(Event, u64) -> ClientEvent,
@@ -595,7 +595,7 @@ mod tests {
         // act
         sut.publish(&EVENT_ID, Event(EVENT_ID, SeqNum(0), DATA1));
         sut.publish(&EVENT_ID, Event(EVENT_ID, SeqNum(0), DATA2));
-        // TODO investigate how to avoid sleeping here
+        // DevSkim: ignore DS176209 TODO investigate how to avoid sleeping here
         // see also: https://github.com/tokio-rs/tokio/issues/2443
         std::thread::sleep(Duration::from_secs_f64(0.1));
         // assert

--- a/ess/src/ess.rs
+++ b/ess/src/ess.rs
@@ -369,8 +369,7 @@ where
     ClientId: Eq + Hash,
     EventId: Eq + Hash,
 {
-    // DevSkim: ignore DS176209
-    // TODO address too many arguments
+    // DevSkim: ignore DS176209 TODO address too many arguments
     #[allow(clippy::too_many_arguments)]
     async fn serve_with_handlers(
         mut self,
@@ -597,8 +596,7 @@ mod tests {
         // act
         sut.publish(&EVENT_ID, Event(EVENT_ID, SeqNum(0), DATA1));
         sut.publish(&EVENT_ID, Event(EVENT_ID, SeqNum(0), DATA2));
-        // DevSkim: ignore DS176209
-        // TODO investigate how to avoid sleeping here
+        // DevSkim: ignore DS176209 TODO investigate how to avoid sleeping here
         // see also: https://github.com/tokio-rs/tokio/issues/2443
         std::thread::sleep(Duration::from_secs_f64(0.1));
         // assert

--- a/ess/src/ess.rs
+++ b/ess/src/ess.rs
@@ -369,7 +369,9 @@ where
     ClientId: Eq + Hash,
     EventId: Eq + Hash,
 {
-    #[allow(clippy::too_many_arguments)] // DevSkim: ignore DS176209 TODO address too many arguments
+    // DevSkim: ignore DS176209
+    // TODO address too many arguments
+    #[allow(clippy::too_many_arguments)]
     async fn serve_with_handlers(
         mut self,
         f: impl Fn(Event, u64) -> ClientEvent,
@@ -595,7 +597,8 @@ mod tests {
         // act
         sut.publish(&EVENT_ID, Event(EVENT_ID, SeqNum(0), DATA1));
         sut.publish(&EVENT_ID, Event(EVENT_ID, SeqNum(0), DATA2));
-        // DevSkim: ignore DS176209 TODO investigate how to avoid sleeping here
+        // DevSkim: ignore DS176209
+        // TODO investigate how to avoid sleeping here
         // see also: https://github.com/tokio-rs/tokio/issues/2443
         std::thread::sleep(Duration::from_secs_f64(0.1));
         // assert

--- a/examples/applications/cloud-object-detection/src/main.rs
+++ b/examples/applications/cloud-object-detection/src/main.rs
@@ -25,7 +25,7 @@ async fn wain() -> Result<(), Error> {
         "sdv.detection",
         [Intent::Inspect, Intent::Invoke],
         "CLOUD_DETECTION_URL",
-        "http://0.0.0.0:50063",
+        "http://0.0.0.0:50063", // DevSkim: ignore DS137138
         ExecutionLocality::Cloud,
     )
     .await?;

--- a/examples/applications/dog-mode-ui/src/Program.cs
+++ b/examples/applications/dog-mode-ui/src/Program.cs
@@ -98,7 +98,7 @@ app.MapGet("/events", async context =>
             }
         }
     }
-    catch (OperationCanceledException) // TODO investigate why this is needed;
+    catch (OperationCanceledException) // DevSkim: ignore DS176209 TODO investigate why this is needed;
     {                                  // seems to "sometimes" crash the process
         // ignore                      // if browser is closed (request aborted).
     }

--- a/examples/applications/dog-mode-ui/src/Program.cs
+++ b/examples/applications/dog-mode-ui/src/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddSingleton(_ => new SocketsHttpHandler { EnableMultipleHttp2C
 
 builder.Services.AddGrpcClient<ChariottRuntime.ChariottService.ChariottServiceClient>((sp, options) =>
 {
-    options.Address = new Uri("http://localhost:4243/");
+    options.Address = new Uri("http://localhost:4243/"); // DevSkim: ignore DS162092
     options.ChannelOptionsActions.Add(options =>
     {
         options.HttpHandler = sp.GetRequiredService<SocketsHttpHandler>();

--- a/examples/applications/invoke-command/src/main.rs
+++ b/examples/applications/invoke-command/src/main.rs
@@ -26,7 +26,7 @@ async fn wain() -> Result<(), Error> {
         "sdv.invoke.controller",
         [Intent::Discover, Intent::Invoke],
         "MASSAGE_URL",
-        "http://0.0.0.0:50064",
+        "http://0.0.0.0:50064", // DevSkim: ignore DS137138
         ExecutionLocality::Local,
     )
     .await?;

--- a/examples/applications/kv-app/src/main.rs
+++ b/examples/applications/kv-app/src/main.rs
@@ -27,7 +27,7 @@ async fn wain() -> Result<(), Error> {
         "sdv.kvs",
         [Intent::Read, Intent::Write, Intent::Subscribe, Intent::Discover],
         "KVS_URL",
-        "http://0.0.0.0:50064",
+        "http://0.0.0.0:50064", // DevSkim: ignore DS137138
         ExecutionLocality::Local,
     )
     .await?;

--- a/examples/applications/local-object-detection/src/main.rs
+++ b/examples/applications/local-object-detection/src/main.rs
@@ -25,7 +25,7 @@ async fn wain() -> Result<(), Error> {
         "sdv.detection",
         [Intent::Inspect, Intent::Invoke],
         "LOCAL_DETECTION_URL",
-        "http://0.0.0.0:50061",
+        "http://0.0.0.0:50061", // DevSkim: ignore DS137138
         ExecutionLocality::Local,
     )
     .await?;

--- a/examples/applications/lt-provider/src/main.rs
+++ b/examples/applications/lt-provider/src/main.rs
@@ -43,7 +43,7 @@ async fn wain() -> Result<(), Error> {
         "lt.provider",
         [Intent::Invoke],
         "LT_PROVIDER_URL",
-        "http://0.0.0.0:50051",
+        "http://0.0.0.0:50051", // DevSkim: ignore DS137138
         ExecutionLocality::Local,
     )
     .await?;

--- a/examples/applications/mock-vas/src/main.rs
+++ b/examples/applications/mock-vas/src/main.rs
@@ -21,7 +21,7 @@ async fn wain() -> Result<(), Error> {
         "sdv.vdt",
         [Intent::Discover, Intent::Invoke, Intent::Inspect, Intent::Subscribe, Intent::Read],
         "VAS_URL",
-        "http://0.0.0.0:50051",
+        "http://0.0.0.0:50051", // DevSkim: ignore DS137138
         ExecutionLocality::Local,
     )
     .await?;

--- a/examples/applications/run_demo.sh
+++ b/examples/applications/run_demo.sh
@@ -60,16 +60,16 @@ cargo build --workspace
 
 sleep 2
 
-./examples/applications/dog-mode-ui/mock_provider_dog_mode_demo.sh | ANNOUNCE_URL=http://localhost:50051 ./target/debug/mock-vas > target/logs/mock_vas.txt 2>&1 &
+./examples/applications/dog-mode-ui/mock_provider_dog_mode_demo.sh | ANNOUNCE_URL=http://localhost:50051 ./target/debug/mock-vas > target/logs/mock_vas.txt 2>&1 & # DevSkim: ignore DS162092
 MOCK_VAS_PID=$!
-ANNOUNCE_URL=http://localhost:50064 ./target/debug/kv-app > target/logs/kv_app.txt 2>&1 &
-SIMULATED_CAMERA_APP_IMAGES_DIRECTORY=./examples/applications/simulated-camera/images ANNOUNCE_URL=http://localhost:50066 ./target/debug/simulated-camera-app > target/logs/simulated_camera_app.txt 2>&1 &
+ANNOUNCE_URL=http://localhost:50064 ./target/debug/kv-app > target/logs/kv_app.txt 2>&1 & # DevSkim: ignore DS162092
+SIMULATED_CAMERA_APP_IMAGES_DIRECTORY=./examples/applications/simulated-camera/images ANNOUNCE_URL=http://localhost:50066 ./target/debug/simulated-camera-app > target/logs/simulated_camera_app.txt 2>&1 & # DevSkim: ignore DS162092
 CAMERA_PID=$!
 TENSORFLOW_LIB_PATH="$(dirname $(find target -name libtensorflow.so -printf '%T@\t%p\n' | sort -nr | cut -f 2- | head -1))"
-LIBRARY_PATH=$TENSORFLOW_LIB_PATH LD_LIBRARY_PATH=$TENSORFLOW_LIB_PATH CATEGORIES_FILE_PATH=./examples/applications/local-object-detection/models/categories.json ANNOUNCE_URL=http://localhost:50061  ./target/debug/local-object-detection-app > target/logs/local_object_detection_app.txt 2>&1 &
+LIBRARY_PATH=$TENSORFLOW_LIB_PATH LD_LIBRARY_PATH=$TENSORFLOW_LIB_PATH CATEGORIES_FILE_PATH=./examples/applications/local-object-detection/models/categories.json ANNOUNCE_URL=http://localhost:50061  ./target/debug/local-object-detection-app > target/logs/local_object_detection_app.txt 2>&1 & # DevSkim: ignore DS162092
 LOCAL_DETECTION_PID=$!
 if [[ ! -z "$cognitive_endpoint" || ! -z "$cognitive_key" ]]; then
-    COGNITIVE_ENDPOINT=$cognitive_endpoint COGNITIVE_KEY=$cognitive_key ANNOUNCE_URL=http://localhost:50063 ./target/debug/cloud-object-detection-app > target/logs/cloud_object_detection_app.txt 2>&1 &
+    COGNITIVE_ENDPOINT=$cognitive_endpoint COGNITIVE_KEY=$cognitive_key ANNOUNCE_URL=http://localhost:50063 ./target/debug/cloud-object-detection-app > target/logs/cloud_object_detection_app.txt 2>&1 & # DevSkim: ignore DS162092
     CLOUD_DETECTION_PID=$!
 else
     echo "Did not start cloud object detection application. Specify 'cognitive_endpoint' and 'cognitive_key' to start it."

--- a/examples/applications/run_demo.sh
+++ b/examples/applications/run_demo.sh
@@ -60,7 +60,7 @@ cargo build --workspace
 
 sleep 2
 
-./examples/applications/dog-mode-ui/mock_provider_dog_mode_demo.sh | ANNOUNCE_URL=http://localhost:50051 ./target/debug/mock-vas > target/logs/mock_vas.txt 2>&1 &
+./examples/applications/dog-mode-ui/mock_provider_dog_mode_demo.sh | ANNOUNCE_URL=http://localhost:50051 ./target/debug/mock-vas > target/logs/mock_vas.txt 2>&1 & 
 MOCK_VAS_PID=$!
 ANNOUNCE_URL=http://localhost:50064 ./target/debug/kv-app > target/logs/kv_app.txt 2>&1 &
 SIMULATED_CAMERA_APP_IMAGES_DIRECTORY=./examples/applications/simulated-camera/images ANNOUNCE_URL=http://localhost:50066 ./target/debug/simulated-camera-app > target/logs/simulated_camera_app.txt 2>&1 &

--- a/examples/applications/run_demo.sh
+++ b/examples/applications/run_demo.sh
@@ -60,7 +60,7 @@ cargo build --workspace
 
 sleep 2
 
-./examples/applications/dog-mode-ui/mock_provider_dog_mode_demo.sh | ANNOUNCE_URL=http://localhost:50051 ./target/debug/mock-vas > target/logs/mock_vas.txt 2>&1 & 
+./examples/applications/dog-mode-ui/mock_provider_dog_mode_demo.sh | ANNOUNCE_URL=http://localhost:50051 ./target/debug/mock-vas > target/logs/mock_vas.txt 2>&1 &
 MOCK_VAS_PID=$!
 ANNOUNCE_URL=http://localhost:50064 ./target/debug/kv-app > target/logs/kv_app.txt 2>&1 &
 SIMULATED_CAMERA_APP_IMAGES_DIRECTORY=./examples/applications/simulated-camera/images ANNOUNCE_URL=http://localhost:50066 ./target/debug/simulated-camera-app > target/logs/simulated_camera_app.txt 2>&1 &

--- a/examples/applications/simple-provider/src/main.rs
+++ b/examples/applications/simple-provider/src/main.rs
@@ -135,9 +135,9 @@ chariott::provider::main!(wain);
 
 async fn wain() -> Result<(), Error> {
     // Intitialize addresses for provider and chariott communication.
-    let chariott_url = "http://0.0.0.0:4243".to_string();
+    let chariott_url = "http://0.0.0.0:4243".to_string(); // DevSkim: ignore DS137138
     let base_provider_address = "0.0.0.0:50064".to_string();
-    let provider_url_str = format!("http://{}", base_provider_address.clone());
+    let provider_url_str = format!("http://{}", base_provider_address.clone()); // DevSkim: ignore DS137138
     let socket_address: SocketAddr = base_provider_address
         .clone()
         .parse()

--- a/examples/applications/simulated-camera/src/main.rs
+++ b/examples/applications/simulated-camera/src/main.rs
@@ -21,7 +21,7 @@ async fn wain() -> Result<(), Error> {
         "sdv.camera.simulated",
         [Intent::Discover, Intent::Subscribe, Intent::Inspect, Intent::Read],
         "SIMULATED_CAMERA_URL",
-        "http://0.0.0.0:50066",
+        "http://0.0.0.0:50066", // DevSkim: ignore DS137138
         ExecutionLocality::Local,
     )
     .await?;

--- a/examples/common/src/chariott/api.rs
+++ b/examples/common/src/chariott/api.rs
@@ -290,7 +290,6 @@ impl<T: ChariottCommunication> Chariott for T {
                     .map(|v| {
                         Value::try_from(v).map_err(|_| Error::new("Could not parse read value."))
                     })
-                    // DevSkim: ignore DS176209 TODO: replace with common::OptionExt after #13
                     .map_or(Ok(None), |r| r.map(Some)),
                 None => Ok(None),
             })

--- a/examples/common/src/chariott/api.rs
+++ b/examples/common/src/chariott/api.rs
@@ -290,7 +290,7 @@ impl<T: ChariottCommunication> Chariott for T {
                     .map(|v| {
                         Value::try_from(v).map_err(|_| Error::new("Could not parse read value."))
                     })
-                    // TODO: replace with common::OptionExt after #13
+                    // DevSkim: ignore DS176209 TODO: replace with common::OptionExt after #13
                     .map_or(Ok(None), |r| r.map(Some)),
                 None => Ok(None),
             })

--- a/service_discovery/core/src/service_registry_impl.rs
+++ b/service_discovery/core/src/service_registry_impl.rs
@@ -222,7 +222,7 @@ mod registry_impl_test {
             namespace: String::from("sdv.test"),
             name: String::from("test_service"),
             version: String::from("1.0.0.0"),
-            uri: String::from("localhost:1000"),
+            uri: String::from("localhost:1000"), // DevSkim: ignore DS162092
             communication_kind: String::from("grpc+proto"),
             communication_reference: String::from("sdv.test.test_service.v1.proto"),
         };
@@ -244,7 +244,7 @@ mod registry_impl_test {
         );
 
         // Test adding a registration with same identifier fails
-        service1.uri = String::from("localhost:1001");
+        service1.uri = String::from("localhost:1001"); // DevSkim: ignore DS162092
         let existing_service_request =
             tonic::Request::new(RegisterRequest { service: Some(service1.clone()) });
         let existing_service_result = registry_impl.register(existing_service_request).await;
@@ -264,7 +264,7 @@ mod registry_impl_test {
             namespace: String::from("sdv.test"),
             name: String::from("test_service"),
             version: String::from("1.0.0.0"),
-            uri: String::from("localhost:1000"),
+            uri: String::from("localhost:1000"), // DevSkim: ignore DS162092
             communication_kind: String::from("grpc+proto"),
             communication_reference: String::from("sdv.test.test_service.v1.proto"),
         };
@@ -313,7 +313,7 @@ mod registry_impl_test {
             namespace: String::from("sdv.test"),
             name: String::from("test_service"),
             version: String::from("1.0.0.0"),
-            uri: String::from("localhost:1000"),
+            uri: String::from("localhost:1000"), // DevSkim: ignore DS162092
             communication_kind: String::from("grpc+proto"),
             communication_reference: String::from("sdv.test.test_service.v1.proto"),
         };
@@ -372,7 +372,7 @@ mod registry_impl_test {
             namespace: String::from("sdv.test"),
             name: String::from("test_service"),
             version: String::from("1.0.0.0"),
-            uri: String::from("localhost:1000"),
+            uri: String::from("localhost:1000"), // DevSkim: ignore DS162092
             communication_kind: String::from("grpc+proto"),
             communication_reference: String::from("sdv.test.test_service.v1.proto"),
         };
@@ -380,7 +380,7 @@ mod registry_impl_test {
             namespace: String::from("sdv.test"),
             name: String::from("test_service"),
             version: String::from("2.0.0.0"),
-            uri: String::from("localhost:2000"),
+            uri: String::from("localhost:2000"), // DevSkim: ignore DS162092
             communication_kind: String::from("grpc+proto"),
             communication_reference: String::from("sdv.test.test_service.v2.proto"),
         };

--- a/service_discovery/samples/simple-discovery/consumer/src/main.rs
+++ b/service_discovery/samples/simple-discovery/consumer/src/main.rs
@@ -21,7 +21,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 /// URL for the service registry
-const SERVICE_REGISTRY_URL: &str = "http://0.0.0.0:50000";
+const SERVICE_REGISTRY_URL: &str = "http://0.0.0.0:50000"; // DevSkim: ignore DS137138
 /// Expected provider communication kind. Validate against this to ensure we can communicate with the service that the service registry returns
 const EXPECTED_COMMUNICATION_KIND: &str = "grpc+proto";
 /// Expected provider communication reference. Validate against this to ensure we can communicate with the service that the service registry returns

--- a/service_discovery/samples/simple-discovery/provider/src/main.rs
+++ b/service_discovery/samples/simple-discovery/provider/src/main.rs
@@ -28,7 +28,7 @@ use tracing_subscriber::EnvFilter;
 mod hello_world_impl;
 
 /// URL for the service registry
-const SERVICE_REGISTRY_URL: &str = "http://0.0.0.0:50000";
+const SERVICE_REGISTRY_URL: &str = "http://0.0.0.0:50000"; // DevSkim: ignore DS137138
 /// Endpoint for the hello world service, which is also a provider
 const HELLO_WORLD_ENDPOINT: &str = "0.0.0.0:50064";
 /// communication kind for this service

--- a/service_discovery/samples/simple-discovery/provider/src/main.rs
+++ b/service_discovery/samples/simple-discovery/provider/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     collector.init();
 
     // Intitialize addresses for provider communication.
-    let provider_url_str = format!("http://{HELLO_WORLD_ENDPOINT}");
+    let provider_url_str = format!("http://{HELLO_WORLD_ENDPOINT}"); // DevSkim: ignore DS137138
     let socket_address: SocketAddr = HELLO_WORLD_ENDPOINT
         .parse()
         .map_err(|e| Error::from_error("error getting SocketAddr", Box::new(e)))?;

--- a/src/chariott_grpc.rs
+++ b/src/chariott_grpc.rs
@@ -441,7 +441,7 @@ mod tests {
             service: Some(IntentServiceRegistration {
                 name: "test".to_string(),
                 version: "1.0".to_string(),
-                url: "http://test.com".to_string(),
+                url: "http://test.com".to_string(), // DevSkim: ignore DS137138
                 locality: ExecutionLocality::Local as i32,
             }),
         }
@@ -452,7 +452,7 @@ mod tests {
             service: Some(IntentServiceRegistration {
                 name: "test".to_string(),
                 version: "1.0".to_string(),
-                url: "http://test.com".to_string(),
+                url: "http://test.com".to_string(), // DevSkim: ignore DS137138
                 locality: ExecutionLocality::Local as i32,
             }),
             intents: vec![
@@ -473,7 +473,7 @@ mod tests {
             service: Some(IntentServiceRegistration {
                 name: "test".to_string(),
                 version: "1.0".to_string(),
-                url: "http://test.com".to_string(),
+                url: "http://test.com".to_string(), // DevSkim: ignore DS137138
                 locality: ExecutionLocality::Local as i32,
             }),
             intents: vec![

--- a/src/chariott_grpc.rs
+++ b/src/chariott_grpc.rs
@@ -432,7 +432,7 @@ mod tests {
 
     fn setup() -> ChariottServer<IntentBroker> {
         let broker =
-            IntentBroker::new("https://localhost:4243".parse().unwrap(), StreamingEss::new());
+            IntentBroker::new("https://localhost:4243".parse().unwrap(), StreamingEss::new()); // DevSkim: ignore DS162092
         ChariottServer::new(Registry::new(broker.clone(), Default::default()), broker)
     }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -348,7 +348,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn system_discover_binding_succeeds() {
         // arrange
-        let url: Url = "http://localhost:4243".parse().unwrap();
+        let url: Url = "http://localhost:4243".parse().unwrap(); // DevSkim: ignore DS162092
 
         // act
         let result = RuntimeBinding::<GrpcProvider>::SystemDiscover(url.clone())

--- a/src/intent_broker.rs
+++ b/src/intent_broker.rs
@@ -257,7 +257,7 @@ mod tests {
                 intent: intent.clone(),
                 service: ServiceConfigurationBuilder::new()
                     .name(name)
-                    .url(&format!("http://{}", name))
+                    .url(&format!("http://{}", name)) // DevSkim: ignore DS137138
                     .execution_locality(locality),
             }),
         );
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn when_refreshing_does_not_depend_on_previous_state() {
         // arrange
-        const SERVICE_URL: &str = "http://service_b";
+        const SERVICE_URL: &str = "http://service_b"; // DevSkim: ignore DS137138
         let setup = Setup::new();
         let service_b = setup.service.clone().url(SERVICE_URL).build();
         let subject = setup.clone().build();

--- a/src/intent_broker.rs
+++ b/src/intent_broker.rs
@@ -179,7 +179,7 @@ mod tests {
     fn when_empty_does_not_resolve() {
         // arrange
         let subject =
-            IntentBroker::new("https://localhost:4243".parse().unwrap(), StreamingEss::new());
+            IntentBroker::new("https://localhost:4243".parse().unwrap(), StreamingEss::new()); // DevSkim: ignore DS162092
 
         // act + assert
         assert!(subject.resolve(&IntentConfigurationBuilder::new().build()).is_none());
@@ -409,7 +409,7 @@ mod tests {
     }
 
     impl Setup {
-        const STREAMING_URL: &str = "https://localhost:4243";
+        const STREAMING_URL: &str = "https://localhost:4243"; // DevSkim: ignore DS162092
 
         fn new() -> Self {
             let intent = IntentConfigurationBuilder::new().build();
@@ -440,7 +440,7 @@ mod tests {
 
         fn combine(setups: impl IntoIterator<Item = Setup>) -> IntentBroker {
             let broker =
-                IntentBroker::new("https://localhost:4243".parse().unwrap(), StreamingEss::new());
+                IntentBroker::new("https://localhost:4243".parse().unwrap(), StreamingEss::new()); // DevSkim: ignore DS162092
 
             let services_by_intent = setups.into_iter().fold(HashMap::new(), |mut acc, s| {
                 acc.entry(s.intent.clone()).or_insert_with(Vec::new).push(s.service);

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let broker = IntentBroker::new(
         format!(
             "http://{}:{}",
-            env::<String>(EXTERNAL_HOST_NAME_ENV).as_deref().unwrap_or("localhost"),
+            env::<String>(EXTERNAL_HOST_NAME_ENV).as_deref().unwrap_or("localhost"), // DevSkim: ignore DS162092
             PORT
         )
         .parse()

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let streaming_ess = StreamingEss::new();
     let broker = IntentBroker::new(
         format!(
-            "http://{}:{}",
+            "http://{}:{}", // DevSkim: ignore DS137138
             env::<String>(EXTERNAL_HOST_NAME_ENV).as_deref().unwrap_or("localhost"), // DevSkim: ignore DS162092
             PORT
         )

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -481,7 +481,7 @@ pub(crate) mod tests {
         let setup = Setup::new();
         let mut registry = setup.clone().build();
         let service = setup.service.clone().build();
-        let updated_service = setup.service.url("http://updated_url").build();
+        let updated_service = setup.service.url("http://updated_url").build(); // DevSkim: ignore DS137138
 
         // act
         registry.upsert(updated_service.clone(), setup.intents.clone(), now()).unwrap();
@@ -531,7 +531,7 @@ pub(crate) mod tests {
         // arrange
         let service_a = ServiceConfigurationBuilder::with_nonce("A");
         let service_b = ServiceConfigurationBuilder::with_nonce("B");
-        let service_a_reregistration = service_a.clone().url("http://service-a-new").build();
+        let service_a_reregistration = service_a.clone().url("http://service-a-new").build(); // DevSkim: ignore DS137138
 
         let intent_1 = IntentConfigurationBuilder::with_nonce("1").build();
         let intent_2 = IntentConfigurationBuilder::with_nonce("2").build();
@@ -755,12 +755,12 @@ pub(crate) mod tests {
     fn test_create_new_service_configuration() {
         let service = ServiceConfiguration::new(
             ServiceId::new("name", "version"),
-            "http://foo".parse().unwrap(),
+            "http://foo".parse().unwrap(), // DevSkim: ignore DS137138
             ExecutionLocality::Local,
         );
         assert_eq!(service.id.name(), "name".into());
         assert_eq!(service.id.version(), "version".into());
-        assert_eq!(service.url, "http://foo".parse().unwrap());
+        assert_eq!(service.url, "http://foo".parse().unwrap()); // DevSkim: ignore DS137138
         assert_eq!(service.locality, ExecutionLocality::Local);
     }
 
@@ -1085,7 +1085,7 @@ pub(crate) mod tests {
         pub fn with_nonce(nonce: impl std::fmt::Display) -> Self {
             Self(ServiceConfiguration::new(
                 ServiceId::new(format!("mock-service-{nonce}"), "0.1.0"),
-                format!("http://service-{nonce}").parse().unwrap(),
+                format!("http://service-{nonce}").parse().unwrap(), // DevSkim: ignore DS137138
                 ExecutionLocality::Cloud,
             ))
         }

--- a/tests/chariott_integration.rs
+++ b/tests/chariott_integration.rs
@@ -164,7 +164,7 @@ async fn setup(provider: Provider) -> Subject {
 
 async fn setup_multiple(providers: impl IntoIterator<Item = ProviderSetup>) -> Subject {
     let namespace = "sdv.integration".to_owned();
-    let broker = IntentBroker::new("https://localhost:4243".parse().unwrap(), StreamingEss::new());
+    let broker = IntentBroker::new("https://localhost:4243".parse().unwrap(), StreamingEss::new()); // DevSkim: ignore DS162092
     let mut registry = Registry::new(broker.clone(), Default::default());
 
     for ProviderSetup { provider, port, name, locality } in providers {

--- a/tests/container-e2e-tests-wsl2.sh
+++ b/tests/container-e2e-tests-wsl2.sh
@@ -41,7 +41,7 @@ docker run --init --rm --name chariott --detach --publish 4243:4243 "chariott:$T
 
 # build kv-app docker container
 docker build --tag "kv-app:$TAG" --file "$DOCKERFILE_CONTEXT/examples/applications/Dockerfile.kv-app.ci" --build-arg APP_NAME=kv-app "$DOCKERFILE_CONTEXT"
-docker run --init --rm --name kv-app --detach --publish 50064:50064 --env ANNOUNCE_URL=http://host.docker.internal:50064 --env CHARIOTT_URL=http://host.docker.internal:4243 "kv-app:$TAG"
+docker run --init --rm --name kv-app --detach --publish 50064:50064 --env ANNOUNCE_URL=http://host.docker.internal:50064 --env CHARIOTT_URL=http://host.docker.internal:4243 "kv-app:$TAG" # DevSkim: ignore DS137138
 
 # run the end to end tests
 cargo test --test "*e2e"

--- a/tests/provider.rs
+++ b/tests/provider.rs
@@ -44,7 +44,7 @@ impl Provider {
                 .serve_with_incoming(listener),
         );
 
-        format!("http://localhost:{port}").parse().unwrap()
+        format!("http://localhost:{port}").parse().unwrap() // DevSkim: ignore DS162092
     }
 }
 

--- a/tests/registry-e2e.rs
+++ b/tests/registry-e2e.rs
@@ -25,7 +25,7 @@ async fn expired_registrations_are_pruned_after_ttl() -> Result<(), anyhow::Erro
     let builder = RegistrationBuilder::new(
         "e2e",
         "1.0.0",
-        "http://localhost/".parse().unwrap(),
+        "http://localhost/".parse().unwrap(), // DevSkim: ignore DS162092
         &namespace,
         [Intent::Inspect],
         ExecutionLocality::Local,
@@ -60,7 +60,7 @@ async fn when_provider_registers_notifies_registry_observers() -> anyhow::Result
     let builder = RegistrationBuilder::new(
         "registration.provider.e2e",
         "1.0.0",
-        "http://localhost:7090".parse().unwrap(), // arbitrary url, the provider will never be invoked
+        "http://localhost:7090".parse().unwrap(), // // DevSkim: ignore DS162092 arbitrary url, the provider will never be invoked
         &namespace,
         [Intent::Inspect],
         ExecutionLocality::Local,

--- a/tests/registry-e2e.rs
+++ b/tests/registry-e2e.rs
@@ -60,7 +60,8 @@ async fn when_provider_registers_notifies_registry_observers() -> anyhow::Result
     let builder = RegistrationBuilder::new(
         "registration.provider.e2e",
         "1.0.0",
-        "http://localhost:7090".parse().unwrap(), // // DevSkim: ignore DS162092 arbitrary url, the provider will never be invoked
+        // arbitrary url, the provider will never be invoked
+        "http://localhost:7090".parse().unwrap(), // DevSkim: ignore DS162092
         &namespace,
         [Intent::Inspect],
         ExecutionLocality::Local,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Addresses #190 

## Motivation and Context
Ignores TLS warning by adding Devskim ignore to http endpoints and localhost. 
## Description
Ignores TLS warning by adding Devskim ignore to http endpoints and localhost. This gets rid of some security warnings that are not truly an issue as they all point to localhost. Most of the "localhost" references are in test code, but some are in our examples, which we don't expect to be used in production. Customers would use their own endpoints for their applications. Also suppress some "TODOs" in code paths that we don't anticipate will have further development on them for now.

Note: the only remaining devskim alerts should be in files that aren't as easy to suppress (i.e. some js files that are marked "generated" and come from somewhere else)