### PR TITLE
Remove v1 of the mobile net to resolve storage issues in workflows

### DIFF
--- a/examples/applications/local-object-detection/models/readme.txt
+++ b/examples/applications/local-object-detection/models/readme.txt
@@ -1,4 +1,2 @@
 Model used in this folder is 'ssd_mobilenet_v2_coco' taken from
 https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md.
-This folder also contains 'ssd_mobilenet_v1_coco' from the same directory, which can be used in WSL
-Ubuntu 20.04 but has had some compatibility issues in other environments.

--- a/examples/applications/local-object-detection/models/ssd_mobilenet_v1_coco.pb
+++ b/examples/applications/local-object-detection/models/ssd_mobilenet_v1_coco.pb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0cb4161a6310632814cd25afe11c261cff9a7d55487a813acd54772285b54850
-size 29103956


### PR DESCRIPTION
## Motivation and Context
Removing the first version of the model because having 2 versions seems to push us over storage quota.

## Description
Resolving the following error in the workflows. It seems like two versions of the model pushes us over our storage quota:
Error: Command 'git' failed with args '-c user.name=github-action-benchmark -c user.email=github@users.noreply.github.com -c http.https://github.com/.extraheader= checkout -': Downloading examples/applications/local-object-detection/models/ssd_mobilenet_v1_coco.pb (29 MB)
Error downloading object: examples/applications/local-object-detection/models/ssd_mobilenet_v1_coco.pb (0cb4161): Smudge error: Error downloading examples/applications/local-object-detection/models/ssd_mobilenet_v1_coco.pb (0cb4161a6310632814cd25afe11c261cff9a7d55487a813acd5[47](https://github.com/eclipse-chariott/chariott/actions/runs/6339355971/job/17218309615#step:6:48)72285b54850): batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.

