### PR TITLE
Update rust toolchain to 1.70

### DIFF
--- a/ess/benches/load_bench.rs
+++ b/ess/benches/load_bench.rs
@@ -53,7 +53,7 @@ fn event_sub_system_bench(c: &mut Criterion) {
                 let (_, mut receiver_stream) = sut.read_events(client_id.clone());
                 {
                     let sender = sender.clone();
-                    _ = runtime.handle().spawn(async move {
+                    runtime.handle().spawn(async move {
                         let mut count: usize = 0;
                         while (receiver_stream.next().await).is_some() {
                             count += 1;

--- a/ess/src/ess.rs
+++ b/ess/src/ess.rs
@@ -223,7 +223,7 @@ where
     {
         let client_by_id = self.client_by_id.read().unwrap();
         match client_by_id.get(client_id) {
-            Some(client) => client.subscriptions.iter().map(|(id, _)| id.clone()).collect(),
+            Some(client) => client.subscriptions.keys().cloned().collect(),
             None => vec![],
         }
     }

--- a/examples/applications/lt-consumer/src/main.rs
+++ b/examples/applications/lt-consumer/src/main.rs
@@ -56,8 +56,7 @@ async fn wain() -> Result<(), Error> {
     let invoke_count: u64 = env(TARGET_INVOKE_COUNT_ENV).unwrap();
     let target_rate: u32 = env(TARGET_RATE_ENV).unwrap();
     let collect_docker_stats = env(COLLECT_DOCKER_STATS_ENV).unwrap_or(false);
-    let chunk_execution_duration =
-        Duration::from_millis(1_000 * CHUNK_SIZE as u64 / target_rate as u64);
+    let chunk_execution_duration = Duration::from_millis(1_000 * CHUNK_SIZE / target_rate as u64);
 
     let chariott = GrpcChariott::connect().await?;
     let latency_metric = Arc::new(Mutex::new(Summary::with_defaults()));
@@ -104,7 +103,7 @@ async fn wain() -> Result<(), Error> {
             let latency_metric = Arc::clone(&latency_metric);
             let invoke_fulfillments = Arc::clone(&invoke_fulfillments);
 
-            _ = tokio::task::spawn(async move {
+            tokio::task::spawn(async move {
                 // Measure the latency based on the sample rate.
                 let now = if c % SAMPLE_RATE == 0 { Some(Instant::now()) } else { None };
 

--- a/examples/applications/simple-provider/src/main.rs
+++ b/examples/applications/simple-provider/src/main.rs
@@ -110,7 +110,7 @@ async fn register_and_announce_provider(
     ttl_seconds: u64,
 ) -> Result<(), Error> {
     // Initiate registration and announce thread.
-    _ = tokio::task::spawn(async move {
+    tokio::task::spawn(async move {
         let mut client = None;
 
         // Loop that handles provider registration and announce heartbeat pattern.

--- a/examples/common/src/chariott/provider.rs
+++ b/examples/common/src/chariott/provider.rs
@@ -75,7 +75,7 @@ pub async fn register(
     // Potential race condition if we register before the server is up.
     // Since this is only an example, we do not ensure that the race does not
     // happen.
-    _ = tokio::task::spawn(registration.register());
+    tokio::task::spawn(registration.register());
 
     Ok((announce_url, socket_address))
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.72"
+channel = "1.70"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.65"
+channel = "1.72"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -166,8 +166,8 @@ impl<T: Observer> Registry<T> {
         change_series.observe(&self.observer, self);
 
         self.known_services
-            .iter()
-            .map(|(_, ts)| *ts + ttl)
+            .values()
+            .map(|ts| *ts + ttl)
             .min()
             .map(|t| (Specific, t))
             .unwrap_or((Default, timestamp + ttl))

--- a/tests/provider.rs
+++ b/tests/provider.rs
@@ -38,7 +38,7 @@ impl Provider {
         socket.bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)).unwrap();
         let listener = TcpListenerStream::new(socket.listen(2).unwrap());
 
-        _ = spawn(
+        spawn(
             Server::builder()
                 .add_service(ProviderServiceServer::new(self))
                 .serve_with_incoming(listener),


### PR DESCRIPTION
## Motivation and Context
Update rust toolchain to 1.70. This will help unblock the notice file generation workflow which is currently failing.

## Description
Update rust toolchain file to 1.70. Resolve clippy errors that were caught by new rust rules