### PR TITLE
Add GIT_LFS_SKIP_SMUDGE var to failing workflows

### DIFF
--- a/.github/workflows/ess-bench.yml
+++ b/.github/workflows/ess-bench.yml
@@ -44,6 +44,8 @@ jobs:
         run: cargo bench --manifest-path ess/Cargo.toml --bench load_bench -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result
+        env:
+          GIT_LFS_SKIP_SMUDGE: 1
         uses: benchmark-action/github-action-benchmark@v1
         if: ${{ github.event_name != 'workflow_dispatch' }}
         with:

--- a/.github/workflows/lt-ci.yml
+++ b/.github/workflows/lt-ci.yml
@@ -161,6 +161,8 @@ jobs:
           find -type f -name "*.out" -exec cat {} \; | jq '.[]' | jq -s > lt-output/all.json
 
       - name: Store combined benchmark result
+        env:
+          GIT_LFS_SKIP_SMUDGE: 1
         uses: benchmark-action/github-action-benchmark@v1
         if: ${{ github.event_name != 'workflow_dispatch' }}
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The benchmark action runs checkout with LFS. This env var should tell git to checkout without LFS. This will protect the LFS quota that we have.

## Description
<!--- Describe your changes in detail -->
The benchmark action runs checkout with LFS. The 'GIT_LFS_SKIP_SMUDGE' env var should tell git to checkout without LFS. This will protect the LFS quota that we have. We do not need the LFS files for these workflows so we are okay using the env variable
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[fix]: Fix LFS issue in pipelines</description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
