### PR TITLE
Fully qualify docker image registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-ARG RUST_VERSION=1.65
-FROM rust:${RUST_VERSION} AS builder
+ARG RUST_VERSION=1.70
+FROM docker.io/library/rust:${RUST_VERSION} AS builder
 
 # Dockerfile for building Eclipse Chariott runtime container
 #

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -2,8 +2,8 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-ARG RUST_VERSION=1.65
-FROM rust:${RUST_VERSION} AS builder
+ARG RUST_VERSION=1.70
+FROM docker.io/library/rust:${RUST_VERSION} AS builder
 
 # Dockerfile for building Eclipse Chariott container for ARM64 with
 # cross-compilation.

--- a/Dockerfile.service_discovery
+++ b/Dockerfile.service_discovery
@@ -2,8 +2,8 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-ARG RUST_VERSION=1.65
-FROM rust:${RUST_VERSION} AS builder
+ARG RUST_VERSION=1.70
+FROM docker.io/library/rust:${RUST_VERSION} AS builder
 
 # Dockerfile for building Eclipse Chariott Service Discovery container
 #

--- a/Dockerfile.valgrind
+++ b/Dockerfile.valgrind
@@ -2,8 +2,8 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-ARG RUST_VERSION=1.65
-FROM rust:${RUST_VERSION} AS builder
+ARG RUST_VERSION=1.70
+FROM docker.io/library/rust:${RUST_VERSION} AS builder
 
 # Dockerfile for building Eclipse Chariott container
 #

--- a/examples/applications/Dockerfile.base
+++ b/examples/applications/Dockerfile.base
@@ -2,8 +2,8 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-ARG RUST_VERSION=1.65
-FROM rust:${RUST_VERSION} AS builder
+ARG RUST_VERSION=1.70
+FROM docker.io/library/rust:${RUST_VERSION} AS builder
 
 # Dockerfile for building Eclipse Chariott base image
 #

--- a/examples/applications/Dockerfile.kv-app.ci
+++ b/examples/applications/Dockerfile.kv-app.ci
@@ -2,8 +2,8 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-ARG RUST_VERSION=1.65
-FROM rust:${RUST_VERSION} AS builder
+ARG RUST_VERSION=1.70
+FROM docker.io/library/rust:${RUST_VERSION} AS builder
 
 # Dockerfile for building Eclipse Chariott container
 #

--- a/examples/applications/Dockerfile.lt-provider-app.ci
+++ b/examples/applications/Dockerfile.lt-provider-app.ci
@@ -2,8 +2,8 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-ARG RUST_VERSION=1.65
-FROM rust:${RUST_VERSION} AS builder
+ARG RUST_VERSION=1.70
+FROM docker.io/library/rust:${RUST_VERSION} AS builder
 
 # Dockerfile for building Eclipse Chariott container
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Fixes #212 

## Motivation and Context
This change allows a user building the Dockerfile in podman to build without needing to first add docker.io to podman's list of unqualified search registries.

## Description
Dockerfile images are now fully qualified as 'docker.io/library/{image}', ensuring the dockerfile can be built without any other podman setup. The rust version in all Dockerfiles now matches the one in rust-toolchain.toml.
