### PR TITLE
Workflow and UID fixes

### DIFF
--- a/.github/workflows/containerize.yaml
+++ b/.github/workflows/containerize.yaml
@@ -17,7 +17,7 @@ on:
     paths:
       - "intent_brokering/src/**"
       - "intent_brokering/proto/**"
-      - "Dockerfile.intent_brokering"
+      - "Dockerfile.intent_brokering.amd64"
       - ".github/workflows/containerize.yaml"
       - "rust-toolchain.toml"
 

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ./Dockerfile.intent_brokering
+          file: ./Dockerfile.intent_brokering.amd64
           load: true
           tags: intent_brokering:1
 

--- a/.github/workflows/lt-ci.yml
+++ b/.github/workflows/lt-ci.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: Dockerfile.intent_brokering
+          file: Dockerfile.intent_brokering.amd64
           load: true
           tags: intent_brokering:1
 

--- a/Dockerfile.service_discovery.arm64
+++ b/Dockerfile.service_discovery.arm64
@@ -22,11 +22,11 @@ WORKDIR /sdv
 
 COPY ./ .
 
-# Check that UID argument is valid.
+# Check that CHARIOTT_UID argument is valid.
 RUN /sdv/container/scripts/argument_sanitizer.sh \
-    --arg-value "${UID}" \
+    --arg-value "${CHARIOTT_UID}" \
     --regex "^[0-9]+$" || \
-    ( echo "Argument sanitizer failed for ARG 'UID'"; exit 1 )
+    ( echo "Argument sanitizer failed for ARG 'CHARIOTT_UID'"; exit 1 )
 
 # unprivileged identity to run Chariott Service Discovery as
 RUN adduser \


### PR DESCRIPTION
## Motivation and Context
Some cleanup changes as a follow up to #265  

## Description
<!--- Describe your changes in detail -->
Fixes failing workflows by updating the name of the dockerfiles to the changes made in the last PR. Also fixes the CHARIOTT_UID variable name in the arm64 Dockerfile argument sanitization.