### PR TITLE
SECURITY.md updated to Eclipse's policy, rust toolchain update

### DIFF
--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -29,5 +29,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
-        npm install markdown-link-check
+        npm install markdown-link-check@3.11.2
         find . -type d \( -name node_modules -o -name .github \) -prune -o -type f -name '*.md' -print0 | xargs -0 -n1 node_modules/.bin/markdown-link-check --config .markdownlinkcheck.jsonc --quiet

--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -29,5 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
+        # markdown-link-check had a regression introduced in version 3.12.0. Keep it at 3.11.2 until that is resolved
+        # Issue: https://github.com/tcort/markdown-link-check/issues/304
         npm install markdown-link-check@3.11.2
         find . -type d \( -name node_modules -o -name .github \) -prune -o -type f -name '*.md' -print0 | xargs -0 -n1 node_modules/.bin/markdown-link-check --config .markdownlinkcheck.jsonc --quiet

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 [workspace]
+# The default resolver for workspaces is different than for regular packages, so use v2 to avoid warnings
+resolver = "2"
 members = [
     "intent_brokering",
     "intent_brokering/common",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,10 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.5 BLOCK -->
+# Security Policy
 
-## Security
+This project implements the Eclipse Foundation Security Policy
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+* https://www.eclipse.org/security
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+## Reporting a Vulnerability
 
-## Reporting Security Issues
-
-**Please do not report security vulnerabilities through public GitHub issues.**
-
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
-
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
-
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
-
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
-
-* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-* Full paths of source file(s) related to the manifestation of the issue
-* The location of the affected source code (tag/branch/commit or direct URL)
-* Any special configuration required to reproduce the issue
-* Step-by-step instructions to reproduce the issue
-* Proof-of-concept or exploit code (if possible)
-* Impact of the issue, including how an attacker might exploit the issue
-
-This information will help us triage your report more quickly.
-
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
-
-## Preferred Languages
-
-We prefer all communications to be in English.
-
-## Policy
-
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
-
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+Please report vulnerabilities to the Eclipse Foundation Security Team at
+security@eclipse.org

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 This project implements the Eclipse Foundation Security Policy
 
-* https://www.eclipse.org/security
+* <https://www.eclipse.org/security>
 
 ## Reporting a Vulnerability
 
 Please report vulnerabilities to the Eclipse Foundation Security Team at
-security@eclipse.org
+<security@eclipse.org>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.70"
+channel = "1.72.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Resolves #281 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For legacy reasons the repository had Microsoft's security policy listed. We need to update it to reflect Eclipse Foundation's policy.

## Description
<!--- Describe your changes in detail -->

- Use Eclipse foundations' security policy in SECURITY.md 
- Update rust toolchain version to 1.72.1

<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[optional scope]: </description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
